### PR TITLE
Add support to build images with self signed or internal certificates

### DIFF
--- a/site-client/Dockerfile
+++ b/site-client/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.9
 
+RUN apt install ca-certificates
+COPY ./*.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 RUN pip install requests==2.22.0
 RUN pip install pandas==1.4.4
 RUN useradd -r -s /bin/false 10001

--- a/site-client/docker-entrypoint.sh
+++ b/site-client/docker-entrypoint.sh
@@ -3,6 +3,7 @@
 FHIR_BASE_URL=${FHIR_BASE_URL:-"http://fhir-server:8080/fhir"}
 BROKER_ENDPOINT_URI=${BROKER_ENDPOINT_URI:-"http://aktin-broker:8080/broker/"}
 CLIENT_AUTH_PARAM=${CLIENT_AUTH_PARAM:-"xxxApiKey123"}
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
 echo "Begin generating report..."
 


### PR DESCRIPTION
Allows to build the image with self signed or internal certificates if needed. This change should not break anything if no custom certificates are used.

The changes in the `Dockerfile` allows to save trusted x509 certificates (.crt) files along the Dockerfile and rebuild the image. The certificate files will be copied into the image and the OS's trust store will be updated.

The change in the `docker-entrypoint.sh` ensures that requests are validated against the CA certificates of the images OS instead of the Mozilla CA bundle from the `certifi` Python package (which is the default for current `requests` versions).